### PR TITLE
feat: implement adjustable probability of true boolean creation

### DIFF
--- a/object_mother_pattern/mothers/primitives/boolean_mother.py
+++ b/object_mother_pattern/mothers/primitives/boolean_mother.py
@@ -9,7 +9,7 @@ if version_info >= (3, 12):
 else:
     from typing_extensions import override  # pragma: no cover
 
-from random import choice
+from random import sample
 
 from object_mother_pattern.mothers.base_mother import BaseMother
 
@@ -32,16 +32,21 @@ class BooleanMother(BaseMother[bool]):
 
     @classmethod
     @override
-    def create(cls, *, value: bool | None = None) -> bool:
+    def create(cls, *, value: bool | None = None, probabilty_true: float = 0.5) -> bool:
         """
         Create a boolean value. If a specific boolean value is provided via `value`, it is returned after validation.
-        Otherwise, a random boolean is generated.
+        Otherwise, a random boolean is generated with a probabiblity of returning True defined by `probabilty_true`.
 
         Args:
             value (bool | None, optional): A specific boolean value to return. Defaults to None.
+            probabilty_true (float, optional): Probability of returning True. Must be >= 0.0 and <= 1.0. Defaults to
+            0.5.
 
         Raises:
             TypeError: If the provided `value` is not a boolean.
+            TypeError: If `probabilty_true` is not a float.
+            ValueError: If `probabilty_true` is less than 0.0.
+            ValueError: If `probability_true` is more than 1.0.
 
         Returns:
             bool: A randomly generated boolean value.
@@ -61,7 +66,18 @@ class BooleanMother(BaseMother[bool]):
 
             return value
 
-        return choice(seq=(True, False))  # noqa: S311
+        if type(probabilty_true) is not float:
+            raise TypeError('BooleanMother probabilty_true must be a float.')
+
+        if probabilty_true < 0.0:
+            raise ValueError('BooleanMother probabilty_true must be greater than or equal to 0.0.')
+
+        if probabilty_true > 1.0:
+            raise ValueError('BooleanMother probabilty_true must be less than or equal to 1.0.')
+
+        return sample(
+            population=(True, False), k=1, counts=(int(probabilty_true * 100), int(100 - probabilty_true * 100))
+        )[0]  # noqa: S311
 
     @classmethod
     def true(cls) -> bool:

--- a/tests/mothers/primitives/test_boolean_mother.py
+++ b/tests/mothers/primitives/test_boolean_mother.py
@@ -2,9 +2,11 @@
 Test module for the BooleanMother class.
 """
 
+from math import inf, nextafter
+
 from pytest import mark, raises as assert_raises
 
-from object_mother_pattern.mothers import BooleanMother
+from object_mother_pattern.mothers import BooleanMother, FloatMother
 
 
 @mark.unit_testing
@@ -37,6 +39,86 @@ def test_boolean_mother_create_method_invalid_value_type() -> None:
         match='BooleanMother value must be a boolean.',
     ):
         BooleanMother.create(value=BooleanMother.invalid_type())
+
+
+@mark.unit_testing
+def test_boolean_mother_create_method_probability_true_hundred_percent() -> None:
+    """
+    Check that BooleanMother create method returns True when the probability of True is 1.0.
+    """
+    value = BooleanMother.create(probabilty_true=1.0)
+
+    assert value
+
+
+@mark.unit_testing
+def test_boolean_mother_create_method_probability_true_zero_percent() -> None:
+    """
+    Check that BooleanMother create method returns True when the probability of True is 0.0.
+    """
+    value = BooleanMother.create(probabilty_true=0.0)
+
+    assert not value
+
+
+@mark.unit_testing
+def test_boolean_mother_create_method_invalid_probability_true_type() -> None:
+    """
+    Check that BooleanMother create method raises a TypeError when the provided probability is not a float.
+    """
+    with assert_raises(
+        expected_exception=TypeError,
+        match='BooleanMother probabilty_true must be a float.',
+    ):
+        BooleanMother.create(probabilty_true=FloatMother.invalid_type())
+
+
+@mark.unit_testing
+def test_boolean_mother_create_method_negative_probability_true() -> None:
+    """
+    Check that BooleanMother create method raises a ValueError when the provided probability is less than 0.0.
+    """
+    with assert_raises(
+        expected_exception=ValueError,
+        match='BooleanMother probabilty_true must be greater than or equal to 0.0.',
+    ):
+        BooleanMother.create(probabilty_true=nextafter(0.0, -inf))
+
+
+@mark.unit_testing
+def test_boolean_mother_create_method_random_negative_probability_true() -> None:
+    """
+    Check that BooleanMother create method raises a ValueError when the provided probability is less than 0.0.
+    """
+    with assert_raises(
+        expected_exception=ValueError,
+        match='BooleanMother probabilty_true must be greater than or equal to 0.0.',
+    ):
+        BooleanMother.create(probabilty_true=FloatMother.create(max=nextafter(0.0, -inf)))
+
+
+@mark.unit_testing
+def test_boolean_mother_create_method_greater_than_one_probability_true() -> None:
+    """
+    Check that BooleanMother create method raises a ValueError when the provided probability is more than 1.0.
+    """
+    with assert_raises(
+        expected_exception=ValueError,
+        match='BooleanMother probabilty_true must be less than or equal to 1.0.',
+    ):
+        BooleanMother.create(probabilty_true=nextafter(1.0, inf))
+
+
+@mark.unit_testing
+def test_boolean_mother_create_method_random_positive_probability_true() -> None:
+    """
+    Check that BooleanMother create method raises a ValueError when the provided probability is more than 1.0.
+    """
+    with assert_raises(
+        expected_exception=ValueError,
+        match='BooleanMother probabilty_true must be less than or equal to 1.0.',
+    ):
+        BooleanMother.create(probabilty_true=FloatMother.create(min=nextafter(1.0, inf), max=inf))
 
 
 @mark.unit_testing


### PR DESCRIPTION
# 📑 Description

This pull request introduces enhancements to the `BooleanMother` class, allowing for configurable probabilities when generating random boolean values, with its corresponding tests. 

## 🔖 Type of change

- [x] **✨ feat**: New feature (non-breaking change).
- [ ] **🐛 fix**: Bug fix (non-breaking change).
- [ ] **📚 docs**: Documentation update.
- [ ] **🔨 refactor**: Code change that neither fixes a bug nor adds a new feature.
- [ ] **🚀 perf**: Performance improvement.
- [ ] **🧪 test**: Update suite of tests.
- [ ] **📦 build**: Changes that affect the build system (new dependencies, tools, ...).
- [ ] **🤖 ci**: Pipeline changes (GitHub Actions, make commands, ...).
- [ ] **💥BREAKING CHANGE**: Feature, fix, ... that breaks backward compatibility.
- [ ] **🛠️ others**: Other type of change.

## 🔗 Related Issues / Discussions / Resources

<!--
> 📝 Please include a list of related issues, discussions, or resources.
> - Closes: [#\<issue-number>](https://github.com/adriamontoto/object-mother-pattern/issues/<issue-number>), ...
> - Related to: [#\<issue-number>](https://github.com/adriamontoto/object-mother-pattern/issues/<issue-number>), ...
-->

## ✅ Pre-merge Checklist

- [x] I have read and followed the [`🤝 Contributor Guidelines`](https://github.com/adriamontoto/object-mother-pattern/blob/master/.github/CONTRIBUTING.md).
- [x] I have read and followed the [`🧭 Code of Conduct`](https://github.com/adriamontoto/object-mother-pattern/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] My pull requests and commits follow the [Conventional Commits](https://www.conventionalcommits.org) and [Conventional Comments](https://conventionalcomments.org) guidelines.
- [x] My code follows the coding guidelines of the project ([PEP 8](https://peps.python.org/pep-0008), [PEP 257](https://peps.python.org/pep-0257), ...).
- [x] My changes generate no new warnings (execution, linter, formatter, ...).
- [x] I have updated the suite of tests required for this change.
- [x] I have made corresponding changes to the documentation.
- [x] I considered security & backwards-compatibility; if **breaking**, explain in the "Description" section above.

## 📃 Additional Resources

- [The Anatomy of a Perfect Pull Request](https://hugooodias.medium.com/the-anatomy-of-a-perfect-pull-request-567382bb6067)
