### PR TITLE
feat!: unify cases between mothers

### DIFF
--- a/object_mother_pattern/mothers/__init__.py
+++ b/object_mother_pattern/mothers/__init__.py
@@ -1,8 +1,22 @@
+from enum import StrEnum, unique
+
 from .base_mother import BaseMother
 from .dates import DateMother, DatetimeMother, StringDateMother, StringDatetimeMother
 from .enumeration_mother import EnumerationMother
 from .identifiers import StringUuidMother, UuidMother
 from .primitives import BooleanMother, BytesMother, FloatMother, IntegerMother, StringMother
+
+
+@unique
+class StringCase(StrEnum):
+    """
+    Type of string case.
+    """
+
+    LOWERCASE = 'lowercase'
+    UPPERCASE = 'uppercase'
+    MIXEDCASE = 'mixedcase'
+
 
 __all__ = (
     'BaseMother',
@@ -13,6 +27,7 @@ __all__ = (
     'EnumerationMother',
     'FloatMother',
     'IntegerMother',
+    'StringCase',
     'StringDateMother',
     'StringDatetimeMother',
     'StringMother',

--- a/object_mother_pattern/mothers/extra/text_mother.py
+++ b/object_mother_pattern/mothers/extra/text_mother.py
@@ -2,7 +2,6 @@
 TextMother module.
 """
 
-from enum import StrEnum, unique
 from random import choice, randint
 from sys import version_info
 from typing import assert_never
@@ -12,19 +11,9 @@ if version_info >= (3, 12):
 else:
     from typing_extensions import override  # pragma: no cover
 
+from object_mother_pattern.mothers import StringCase
 from object_mother_pattern.mothers.base_mother import BaseMother
 from object_mother_pattern.mothers.primitives.string_mother import StringMother
-
-
-@unique
-class TextCase(StrEnum):
-    """
-    Type of Text cases.
-    """
-
-    LOWERCASE = 'lowercase'
-    UPPERCASE = 'uppercase'
-    MIXEDCASE = 'mixedcase'
 
 
 class TextMother(BaseMother[str]):
@@ -60,18 +49,18 @@ class TextMother(BaseMother[str]):
         value: str | None = None,
         min_length: int = 1,
         max_length: int = 1024,
-        text_case: TextCase | None = None,
+        string_case: StringCase | None = None,
     ) -> str:
         """
         Create a random text. If a specific text value is provided via `value`, it is returned after
         validation. Otherwise, a random string value is generated with the provided `min_length`, `max_length` (both
-        included). If `text_case` is None, a random case is chosen from the available TextCase options.
+        included). If `string_case` is None, a random case is chosen from the available StringCase options.
 
         Args:
             value (str | None, optional): Text value. Defaults to None.
             min_length (int, optional): Minimum length of the text. Must be >= 1. Defaults to 1.
             max_length (int, optional): Maximum length of the text. Must be >= 1 and >= `min_length`. Defaults to 1024.
-            text_case (TextCase | None, optional): The case of the text. Defaults to None.
+            string_case (StringCase | None, optional): The case of the text. Defaults to None.
 
         Raises:
             TypeError: If `value` is not a string.
@@ -80,7 +69,7 @@ class TextMother(BaseMother[str]):
             ValueError: If `min_length` is less than 1.
             ValueError: If `max_length` is less than 1.
             ValueError: If `min_length` is greater than `max_length`.
-            TypeError: If `text_case` is not a TextCase.
+            TypeError: If `string_case` is not a StringCase.
 
         Returns:
             str: Random text value of length between `min_length` and `max_length` (inclusive).
@@ -124,11 +113,11 @@ class TextMother(BaseMother[str]):
         if min_length > max_length:
             raise ValueError('TextMother min_length must be less than or equal to max_length.')
 
-        if text_case is None:
-            text_case = TextCase(value=choice(seq=tuple(TextCase)))  # noqa: S311
+        if string_case is None:
+            string_case = StringCase(value=choice(seq=tuple(StringCase)))  # noqa: S311
 
-        if type(text_case) is not TextCase:
-            raise TypeError('TextMother text_case must be a TextCase.')
+        if type(string_case) is not StringCase:
+            raise TypeError('TextMother string_case must be a StringCase.')
 
         length = randint(a=min_length, b=max_length)  # noqa: S311
 
@@ -144,18 +133,18 @@ class TextMother(BaseMother[str]):
 
         text = text[:-1] + '.'
 
-        match text_case:
-            case TextCase.LOWERCASE:
+        match string_case:
+            case StringCase.LOWERCASE:
                 text = text.lower()
 
-            case TextCase.UPPERCASE:
+            case StringCase.UPPERCASE:
                 text = text.upper()
 
-            case TextCase.MIXEDCASE:
+            case StringCase.MIXEDCASE:
                 text = ''.join(choice(seq=(char.upper(), char.lower())) for char in text)  # noqa: S311
 
             case _:  # pragma: no cover
-                assert_never(text_case)
+                assert_never(string_case)
 
         return text  # noqa: S311
 

--- a/object_mother_pattern/mothers/identifiers/countries/spain/dni_mother.py
+++ b/object_mother_pattern/mothers/identifiers/countries/spain/dni_mother.py
@@ -2,7 +2,6 @@
 DniMother module for Spanish National Identity Document (DNI).
 """
 
-from enum import StrEnum, unique
 from random import choice, randint
 from sys import version_info
 from typing import assert_never
@@ -12,17 +11,7 @@ if version_info >= (3, 12):
 else:
     from typing_extensions import override  # pragma: no cover
 
-from object_mother_pattern.mothers import BaseMother, StringMother
-
-
-@unique
-class DniCase(StrEnum):
-    """
-    Type of DNI letter cases.
-    """
-
-    LOWERCASE = 'lowercase'
-    UPPERCASE = 'uppercase'
+from object_mother_pattern.mothers import BaseMother, StringCase, StringMother
 
 
 class DniMother(BaseMother[str]):
@@ -48,18 +37,18 @@ class DniMother(BaseMother[str]):
 
     @classmethod
     @override
-    def create(cls, *, value: str | None = None, dni_case: DniCase | None = None) -> str:
+    def create(cls, *, value: str | None = None, string_case: StringCase | None = None) -> str:
         """
         Create a random valid Spanish DNI. If a specific DNI value is provided via `value`, it is returned after
         validation. Otherwise, a random valid DNI is generated.
 
         Args:
             value (str | None, optional): Specific DNI value to return. Defaults to None.
-            dni_case (DniCase | None, optional): The case of the DNI letter. Defaults to None (random case).
+            string_case (StringCase | None, optional): The case of the DNI letter. Defaults to None (random case).
 
         Raises:
             TypeError: If the provided `value` is not a string.
-            TypeError: If the provided `dni_case` is not a DniCase.
+            TypeError: If the provided `string_case` is not a StringCase.
 
         Returns:
             str: A valid Spanish DNI.
@@ -79,24 +68,27 @@ class DniMother(BaseMother[str]):
 
             return value
 
-        if dni_case is None:
-            dni_case = DniCase(value=choice(seq=tuple(DniCase)))  # noqa: S311
+        if string_case is None:
+            string_case = StringCase(value=choice(seq=tuple(StringCase)))  # noqa: S311
 
-        if type(dni_case) is not DniCase:
-            raise TypeError('DniMother dni_case must be a DniCase')
+        if type(string_case) is not StringCase:
+            raise TypeError('DniMother string_case must be a StringCase')
 
         number = randint(a=cls._MIN_NUMBER, b=cls._MAX_NUMBER)  # noqa: S311
         letter = cls._DNI_LETTERS[number % 23]
 
-        match dni_case:
-            case DniCase.LOWERCASE:
+        match string_case:
+            case StringCase.LOWERCASE:
                 letter = letter.lower()
 
-            case DniCase.UPPERCASE:
+            case StringCase.UPPERCASE:
                 letter = letter.upper()
 
+            case StringCase.MIXEDCASE:
+                letter = ''.join(choice(seq=(char.upper(), char.lower())) for char in letter)  # noqa: S311
+
             case _:  # pragma: no cover
-                assert_never(dni_case)
+                assert_never(string_case)
 
         return f'{number:08d}{letter}'
 

--- a/object_mother_pattern/mothers/identifiers/countries/spain/nie_mother.py
+++ b/object_mother_pattern/mothers/identifiers/countries/spain/nie_mother.py
@@ -2,7 +2,6 @@
 NieMother module for Spanish Foreign Identity Number (NIE).
 """
 
-from enum import StrEnum, unique
 from random import choice, randint
 from sys import version_info
 from typing import ClassVar, assert_never
@@ -12,18 +11,7 @@ if version_info >= (3, 12):
 else:
     from typing_extensions import override  # pragma: no cover
 
-from object_mother_pattern.mothers import BaseMother, StringMother
-
-
-@unique
-class NieCase(StrEnum):
-    """
-    Type of NIE letter cases.
-    """
-
-    LOWERCASE = 'lowercase'
-    UPPERCASE = 'uppercase'
-    MIXEDCASE = 'mixedcase'
+from object_mother_pattern.mothers import BaseMother, StringCase, StringMother
 
 
 class NieMother(BaseMother[str]):
@@ -50,18 +38,18 @@ class NieMother(BaseMother[str]):
 
     @classmethod
     @override
-    def create(cls, *, value: str | None = None, nie_case: NieCase | None = None) -> str:
+    def create(cls, *, value: str | None = None, string_case: StringCase | None = None) -> str:
         """
         Create a random valid Spanish NIE. If a specific NIE value is provided via `value`,
         it is returned after validation. Otherwise, a random valid NIE is generated.
 
         Args:
             value (str | None, optional): Specific NIE value to return. Defaults to None.
-            nie_case (NieCase | None, optional): The case of the NIE letters. Defaults to None (random case).
+            string_case (StringCase | None, optional): The case of the NIE letters. Defaults to None (random case).
 
         Raises:
             TypeError: If the provided `value` is not a string.
-            TypeError: If the provided `nie_case` is not a NieCase.
+            TypeError: If the provided `string_case` is not a StringCase.
 
         Returns:
             str: A valid Spanish NIE.
@@ -81,11 +69,11 @@ class NieMother(BaseMother[str]):
 
             return value
 
-        if nie_case is None:
-            nie_case = NieCase(value=choice(seq=tuple(NieCase)))  # noqa: S311
+        if string_case is None:
+            string_case = StringCase(value=choice(seq=tuple(StringCase)))  # noqa: S311
 
-        if type(nie_case) is not NieCase:
-            raise TypeError('NieMother nie_case must be a NieCase')
+        if type(string_case) is not StringCase:
+            raise TypeError('NieMother string_case must be a StringCase')
 
         prefix = choice(seq=tuple(cls._NIE_PREFIXES.keys()))  # noqa: S311
         prefix_num = cls._NIE_PREFIXES[prefix]
@@ -93,18 +81,18 @@ class NieMother(BaseMother[str]):
         letter = cls._NIE_LETTERS[(prefix_num * 10000000 + number) % 23]
 
         nie = f'{prefix}{number:07d}{letter}'
-        match nie_case:
-            case NieCase.LOWERCASE:
+        match string_case:
+            case StringCase.LOWERCASE:
                 nie = nie.lower()
 
-            case NieCase.UPPERCASE:
+            case StringCase.UPPERCASE:
                 nie = nie.upper()
 
-            case NieCase.MIXEDCASE:
+            case StringCase.MIXEDCASE:
                 nie = ''.join(choice(seq=(char.upper(), char.lower())) for char in nie)  # noqa: S311
 
             case _:  # pragma: no cover
-                assert_never(nie_case)
+                assert_never(string_case)
 
         return nie
 

--- a/object_mother_pattern/mothers/internet/domain_mother.py
+++ b/object_mother_pattern/mothers/internet/domain_mother.py
@@ -2,7 +2,6 @@
 DomainMother module.
 """
 
-from enum import StrEnum, unique
 from random import choice, randint, sample
 from sys import version_info
 from typing import assert_never
@@ -12,21 +11,10 @@ if version_info >= (3, 12):
 else:
     from typing_extensions import override  # pragma: no cover
 
-from object_mother_pattern.mothers import StringMother
+from object_mother_pattern.mothers import StringCase, StringMother
 from object_mother_pattern.mothers.base_mother import BaseMother
 
 from .utils import get_label_dict, get_tld_dict
-
-
-@unique
-class DomainCase(StrEnum):
-    """
-    Type of Domain cases.
-    """
-
-    LOWERCASE = 'lowercase'
-    UPPERCASE = 'uppercase'
-    MIXEDCASE = 'mixedcase'
 
 
 class DomainMother(BaseMother[str]):
@@ -55,7 +43,7 @@ class DomainMother(BaseMother[str]):
         max_length: int = 30,
         min_labels: int = 2,
         max_labels: int = 4,
-        domain_case: DomainCase | None = None,
+        string_case: StringCase | None = None,
         include_hyphens: bool = True,
         include_numbers: bool = True,
     ) -> str:
@@ -73,7 +61,7 @@ class DomainMother(BaseMother[str]):
             min_labels (int, optional): The minimum number of labels in the domain. Must be >= 2. Defaults to 2.
             max_labels (int, optional): The maximum number of labels in the domain. Must be <= 127 and >= `min_labels`.
             Defaults to 4.
-            domain_case (DomainCase | None, optional): The case of the domain. Defaults to None.
+            string_case (StringCase | None, optional): The case of the domain. Defaults to None.
             include_hyphens (bool, optional): Whether to include hyphens in the domain. Defaults to True.
             include_numbers (bool, optional): Whether to include numbers in the domain. Defaults to True.
 
@@ -89,7 +77,7 @@ class DomainMother(BaseMother[str]):
             ValueError: If `max_labels` is less than 2.
             ValueError: If `max_labels` is more than 127.
             ValueError: If `min_labels` is greater than `max_labels`.
-            TypeError: If `domain_case` is not a DomainCase.
+            TypeError: If `string_case` is not a StringCase.
             TypeError: If `include_hyphens` is not a boolean.
             TypeError: If `include_numbers` is not a boolean.
             ValueError: If the total letters are not in the feasible range for given labels and constraints.
@@ -142,11 +130,11 @@ class DomainMother(BaseMother[str]):
         if min_labels > max_labels:
             raise ValueError('DomainMother min_labels must be less than or equal to max_labels.')
 
-        if domain_case is None:
-            domain_case = DomainCase(value=choice(seq=tuple(DomainCase)))  # noqa: S311
+        if string_case is None:
+            string_case = StringCase(value=choice(seq=tuple(StringCase)))  # noqa: S311
 
-        if type(domain_case) is not DomainCase:
-            raise TypeError('DomainMother domain_case must be a DomainCase.')
+        if type(string_case) is not StringCase:
+            raise TypeError('DomainMother string_case must be a StringCase.')
 
         if type(include_hyphens) is not bool:
             raise TypeError('DomainMother include_hyphens must be a boolean.')
@@ -173,18 +161,19 @@ class DomainMother(BaseMother[str]):
                 continue
 
         domain = cls._noisy_domain(domain=domain, include_hyphens=include_hyphens, include_numbers=include_numbers)
-        match domain_case:
-            case DomainCase.LOWERCASE:
+
+        match string_case:
+            case StringCase.LOWERCASE:
                 domain = domain.lower()
 
-            case DomainCase.UPPERCASE:
+            case StringCase.UPPERCASE:
                 domain = domain.upper()
 
-            case DomainCase.MIXEDCASE:
+            case StringCase.MIXEDCASE:
                 domain = ''.join(choice(seq=(char.upper(), char.lower())) for char in domain)  # noqa: S311
 
             case _:  # pragma: no cover
-                assert_never(domain_case)
+                assert_never(string_case)
 
         return domain
 

--- a/object_mother_pattern/mothers/internet/mac_address_mother.py
+++ b/object_mother_pattern/mothers/internet/mac_address_mother.py
@@ -13,6 +13,7 @@ from enum import StrEnum, unique
 from random import choice
 from typing import assert_never
 
+from object_mother_pattern.mothers import StringCase
 from object_mother_pattern.mothers.base_mother import BaseMother
 from object_mother_pattern.mothers.primitives.string_mother import StringMother
 
@@ -30,17 +31,6 @@ class MacAddressFormat(StrEnum):
     SPACE = 'space'
     NULL = 'null'
     BROADCAST = 'broadcast'
-
-
-@unique
-class MacAddressCase(StrEnum):
-    """
-    Type of MAC address cases.
-    """
-
-    LOWERCASE = 'lowercase'
-    UPPERCASE = 'uppercase'
-    MIXEDCASE = 'mixedcase'
 
 
 class MacAddressMother(BaseMother[str]):
@@ -73,7 +63,7 @@ class MacAddressMother(BaseMother[str]):
         *,
         value: str | None = None,
         mac_format: MacAddressFormat | None = None,
-        mac_case: MacAddressCase | None = None,
+        string_case: StringCase | None = None,
     ) -> str:
         """
         Create a random MAC address value with a random format and random case (lowercase, uppercase, mixed). If a
@@ -82,12 +72,12 @@ class MacAddressMother(BaseMother[str]):
         Args:
             value (str | None, optional): A specific MAC address value to return. Defaults to None.
             mac_format (MacAddressFormat | None, optional): A specific MAC address format to use. Defaults to None.
-            mac_case (MacAddressCase | None, optional): A specific MAC address case to use. Defaults to None.
+            string_case (StringCase | None, optional): A specific MAC address case to use. Defaults to None.
 
         Raises:
             TypeError: If the provided `value` is not a string.
             ValueError: If the provided `mac_format` is not a valid MAC address format.
-            ValueError: If the provided `mac_case` is not a valid MAC address case.
+            ValueError: If the provided `string_case` is not a valid StringCase.
 
         Returns:
             str: A randomly generated MAC address value.
@@ -113,11 +103,11 @@ class MacAddressMother(BaseMother[str]):
         if type(mac_format) is not MacAddressFormat:
             raise ValueError('MacAddressMother mac_format must be a MacAddressFormat.')
 
-        if mac_case is None:
-            mac_case = MacAddressCase(value=choice(seq=tuple(MacAddressCase)))  # noqa: S311
+        if string_case is None:
+            string_case = StringCase(value=choice(seq=tuple(StringCase)))  # noqa: S311
 
-        if type(mac_case) is not MacAddressCase:
-            raise ValueError('MacAddressMother mac_case must be a MacAddressCase.')
+        if type(string_case) is not StringCase:
+            raise ValueError('MacAddressMother string_case must be a StringCase.')
 
         match mac_format:
             case MacAddressFormat.RAW:
@@ -144,18 +134,18 @@ class MacAddressMother(BaseMother[str]):
             case _:  # pragma: no cover
                 assert_never(mac_format)
 
-        match mac_case:
-            case MacAddressCase.LOWERCASE:
+        match string_case:
+            case StringCase.LOWERCASE:
                 mac_address = mac_address.lower()
 
-            case MacAddressCase.UPPERCASE:
+            case StringCase.UPPERCASE:
                 mac_address = mac_address.upper()
 
-            case MacAddressCase.MIXEDCASE:
+            case StringCase.MIXEDCASE:
                 mac_address = ''.join(choice(seq=(char.upper(), char.lower())) for char in mac_address)  # noqa: S311
 
             case _:  # pragma: no cover
-                assert_never(mac_case)
+                assert_never(string_case)
 
         return mac_address
 

--- a/object_mother_pattern/mothers/money/cryptocurrencies/btc_wallet_mother.py
+++ b/object_mother_pattern/mothers/money/cryptocurrencies/btc_wallet_mother.py
@@ -10,24 +10,12 @@ if version_info >= (3, 12):
 else:
     from typing_extensions import override  # pragma: no cover
 
-from enum import StrEnum, unique
 from random import choice
 from typing import assert_never
 
-from object_mother_pattern.mothers import BaseMother, StringMother
+from object_mother_pattern.mothers import BaseMother, StringCase, StringMother
 
 from .utils import get_bip39_words
-
-
-@unique
-class BtcWalletCase(StrEnum):
-    """
-    Type of BTC wallet address cases.
-    """
-
-    LOWERCASE = 'lowercase'
-    UPPERCASE = 'uppercase'
-    MIXEDCASE = 'mixedcase'
 
 
 class BtcWalletMother(BaseMother[str]):
@@ -53,7 +41,7 @@ class BtcWalletMother(BaseMother[str]):
         *,
         value: str | None = None,
         word_number: int = 12,
-        wallet_case: BtcWalletCase | None = None,
+        string_case: StringCase | None = None,
     ) -> str:
         """
         Create a random BTC wallet address value. If a specific wallet address value is provided via `value`, it is
@@ -63,13 +51,13 @@ class BtcWalletMother(BaseMother[str]):
         Args:
             value (str | None, optional): Specific value to return. Defaults to None.
             word_number (int, optional): The number of words of the wallet address. Must be >= 1. Defaults to 12.
-            wallet_case (BtcWalletCase | None, optional): The case of the wallet address. Defaults to None.
+            string_case (StringCase | None, optional): The case of the wallet address. Defaults to None.
 
         Raises:
             TypeError: If the provided `value` is not a string.
             TypeError: If `word_number` is not an integer.
             TypeError: If `word_number` is not greater than 0.
-            TypeError: If `wallet_case` is not a BtcWalletCase.
+            TypeError: If `string_case` is not a StringCase.
 
         Returns:
             str: A randomly generated BTC wallet address value (separated by spaces).
@@ -95,26 +83,26 @@ class BtcWalletMother(BaseMother[str]):
         if word_number < 1:
             raise ValueError('BtcWalletMother word_number must be greater than or equal to 1.')
 
-        if wallet_case is None:
-            wallet_case = BtcWalletCase(value=choice(seq=tuple(BtcWalletCase)))  # noqa: S311
+        if string_case is None:
+            string_case = StringCase(value=choice(seq=tuple(StringCase)))  # noqa: S311
 
-        if type(wallet_case) is not BtcWalletCase:
-            raise TypeError('BtcWalletMother wallet_case must be a BtcWalletCase.')
+        if type(string_case) is not StringCase:
+            raise TypeError('BtcWalletMother string_case must be a StringCase.')
 
         wallet = ' '.join(choices(population=get_bip39_words(), k=word_number))  # noqa: S311
 
-        match wallet_case:
-            case BtcWalletCase.LOWERCASE:
+        match string_case:
+            case StringCase.LOWERCASE:
                 wallet = wallet.lower()
 
-            case BtcWalletCase.UPPERCASE:
+            case StringCase.UPPERCASE:
                 wallet = wallet.upper()
 
-            case BtcWalletCase.MIXEDCASE:
+            case StringCase.MIXEDCASE:
                 wallet = ''.join(choice(seq=(char.upper(), char.lower())) for char in wallet)  # noqa: S311
 
             case _:  # pragma: no cover
-                assert_never(wallet_case)
+                assert_never(string_case)
 
         return wallet
 

--- a/object_mother_pattern/mothers/people/full_name_mother.py
+++ b/object_mother_pattern/mothers/people/full_name_mother.py
@@ -10,23 +10,10 @@ else:
     from typing_extensions import override  # pragma: no cover
 
 
-from enum import StrEnum, unique
 from random import choice, randint
 from typing import assert_never
 
-from object_mother_pattern.mothers import BaseMother, StringMother
-
-
-@unique
-class FullNameCase(StrEnum):
-    """
-    Type of full name case.
-    """
-
-    LOWERCASE = 'lowercase'
-    UPPERCASE = 'uppercase'
-    TITLECASE = 'titlecase'
-    MIXEDCASE = 'mixedcase'
+from object_mother_pattern.mothers import BaseMother, StringCase, StringMother
 
 
 class FullNameMother(BaseMother[str]):
@@ -53,7 +40,7 @@ class FullNameMother(BaseMother[str]):
         value: str | None = None,
         min_length: int = 3,
         max_length: int = 128,
-        full_name_case: FullNameCase | None = None,
+        string_case: StringCase | None = None,
     ) -> str:
         """
         Create a random string full name value. If a specific string full name value is provided via `value`, it is
@@ -65,7 +52,7 @@ class FullNameMother(BaseMother[str]):
             min_length (int, optional): Minimum length of the full name. Must be >= 1. Defaults to 3.
             max_length (int, optional): Maximum length of the full name. Must be >= 1 and >= `min_length`. Defaults to
             128.
-            full_name_case (FullNameCase | None, optional): The case of the full name. Defaults to None (random case).
+            string_case (StringCase | None, optional): The case of the full name. Defaults to None (randomly chosen).
 
         Raises:
             TypeError: If the provided `value` is not a string.
@@ -74,7 +61,7 @@ class FullNameMother(BaseMother[str]):
             ValueError: If `min_length` is not greater than 0.
             ValueError: If `max_length` is not greater than 0.
             ValueError: If `min_length` is greater than `max_length`.
-            TypeError: If `full_name_case` is not a FullNameCase.
+            TypeError: If `string_case` is not a StringCase.
 
         Returns:
             str: A randomly generated full name value in the provided range.
@@ -109,11 +96,11 @@ class FullNameMother(BaseMother[str]):
         if min_length > max_length:
             raise ValueError('FullNameMother min_length must be less than or equal to max_length.')
 
-        if full_name_case is None:
-            full_name_case = FullNameCase(value=choice(seq=tuple(FullNameCase)))  # noqa: S311
+        if string_case is None:
+            string_case = StringCase(value=choice(seq=tuple(StringCase)))  # noqa: S311
 
-        if type(full_name_case) is not FullNameCase:
-            raise TypeError('FullNameMother full_name_case must be a FullNameCase.')
+        if type(string_case) is not StringCase:
+            raise TypeError('FullNameMother string_case must be a StringCase.')
 
         length = randint(a=min_length, b=max_length)  # noqa: S311
 
@@ -125,21 +112,18 @@ class FullNameMother(BaseMother[str]):
         if name != name.strip():
             name = name[:-1] + cls._random().lexify(text='?').lower()  # pragma: no cover
 
-        match full_name_case:
-            case FullNameCase.LOWERCASE:
+        match string_case:
+            case StringCase.LOWERCASE:
                 name = name.lower()
 
-            case FullNameCase.UPPERCASE:
+            case StringCase.UPPERCASE:
                 name = name.upper()
 
-            case FullNameCase.TITLECASE:
-                name = name.title()
-
-            case FullNameCase.MIXEDCASE:
+            case StringCase.MIXEDCASE:
                 name = ''.join(choice((char.upper(), char.lower())) for char in name)  # noqa: S311
 
             case _:  # pragma: no cover
-                assert_never(full_name_case)
+                assert_never(string_case)
 
         return name
 

--- a/tests/mothers/extra/test_text_mother.py
+++ b/tests/mothers/extra/test_text_mother.py
@@ -4,9 +4,8 @@ Test module for the TextMother class.
 
 from pytest import mark, raises as assert_raises
 
-from object_mother_pattern.mothers import IntegerMother, StringMother
+from object_mother_pattern.mothers import IntegerMother, StringCase, StringMother
 from object_mother_pattern.mothers.extra import TextMother
-from object_mother_pattern.mothers.extra.text_mother import TextCase
 
 
 @mark.unit_testing
@@ -170,7 +169,7 @@ def test_text_mother_create_method_lowercase_case() -> None:
     """
     Test TextMother create method with lowercase case.
     """
-    value = TextMother.create(text_case=TextCase.LOWERCASE)
+    value = TextMother.create(string_case=StringCase.LOWERCASE)
 
     assert value.islower()
 
@@ -180,7 +179,7 @@ def test_text_mother_create_method_uppercase_case() -> None:
     """
     Test TextMother create method with uppercase case.
     """
-    value = TextMother.create(text_case=TextCase.UPPERCASE)
+    value = TextMother.create(string_case=StringCase.UPPERCASE)
 
     assert value.isupper()
 
@@ -190,9 +189,9 @@ def test_text_mother_create_method_mixed_case() -> None:
     """
     Test TextMother create method with mixed case.
     """
-    value = TextMother.create(text_case=TextCase.MIXEDCASE)
+    value = TextMother.create(string_case=StringCase.MIXEDCASE)
 
-    assert any(char.islower() or char.isupper() for char in value)
+    assert all(char.islower() or char.isupper() or char.isdigit() or char.isspace() or char == '.' for char in value)
 
 
 @mark.unit_testing
@@ -202,9 +201,9 @@ def test_text_mother_create_method_invalid_case() -> None:
     """
     with assert_raises(
         expected_exception=TypeError,
-        match='TextMother text_case must be a TextCase.',
+        match='TextMother string_case must be a StringCase.',
     ):
-        TextMother.create(text_case=StringMother.invalid_type())
+        TextMother.create(string_case=StringMother.invalid_type())
 
 
 @mark.unit_testing

--- a/tests/mothers/identifiers/countries/spain/test_dni_mother.py
+++ b/tests/mothers/identifiers/countries/spain/test_dni_mother.py
@@ -6,9 +6,8 @@ from re import Pattern, compile as re_compile
 
 from pytest import mark, raises as assert_raises
 
-from object_mother_pattern.mothers import StringMother
+from object_mother_pattern.mothers import StringCase, StringMother
 from object_mother_pattern.mothers.identifiers.countries.spain import DniMother
-from object_mother_pattern.mothers.identifiers.countries.spain.dni_mother import DniCase
 
 _DNI_REGEX: Pattern[str] = re_compile(pattern=r'^(\d{8})([A-Za-z])$')
 
@@ -50,7 +49,7 @@ def test_dni_mother_lowercase_case() -> None:
     """
     Test DniMother create method with lowercase case.
     """
-    value = DniMother.create(dni_case=DniCase.LOWERCASE)
+    value = DniMother.create(string_case=StringCase.LOWERCASE)
 
     assert value.islower()
 
@@ -60,9 +59,19 @@ def test_dni_mother_uppercase_case() -> None:
     """
     Test DniMother create method with uppercase case.
     """
-    value = DniMother.create(dni_case=DniCase.UPPERCASE)
+    value = DniMother.create(string_case=StringCase.UPPERCASE)
 
     assert value.isupper()
+
+
+@mark.unit_testing
+def test_dni_mother_mixed_case() -> None:
+    """
+    Test DniMother create method with mixed case (should default to uppercase letter).
+    """
+    value = DniMother.create(string_case=StringCase.MIXEDCASE)
+
+    assert value[-1].islower() or value[-1].isupper()
 
 
 @mark.unit_testing
@@ -72,9 +81,9 @@ def test_dni_mother_invalid_case() -> None:
     """
     with assert_raises(
         expected_exception=TypeError,
-        match='DniMother dni_case must be a DniCase',
+        match='DniMother string_case must be a StringCase',
     ):
-        DniMother.create(dni_case=StringMother.invalid_type())
+        DniMother.create(string_case=StringMother.invalid_type())
 
 
 @mark.unit_testing

--- a/tests/mothers/identifiers/countries/spain/test_nie_mother.py
+++ b/tests/mothers/identifiers/countries/spain/test_nie_mother.py
@@ -6,9 +6,8 @@ from re import Pattern, compile as re_compile
 
 from pytest import mark, raises as assert_raises
 
-from object_mother_pattern.mothers import StringMother
+from object_mother_pattern.mothers import StringCase, StringMother
 from object_mother_pattern.mothers.identifiers.countries.spain import NieMother
-from object_mother_pattern.mothers.identifiers.countries.spain.nie_mother import NieCase
 
 _NIE_REGEX: Pattern[str] = re_compile(pattern=r'^([XYZxyz])(\d{7})([A-Za-z])$')
 
@@ -50,7 +49,7 @@ def test_nie_mother_lowercase_case() -> None:
     """
     Test NieMother create method with lowercase case.
     """
-    value = NieMother.create(nie_case=NieCase.LOWERCASE)
+    value = NieMother.create(string_case=StringCase.LOWERCASE)
 
     assert value.islower()
 
@@ -60,7 +59,7 @@ def test_nie_mother_uppercase_case() -> None:
     """
     Test NieMother create method with uppercase case.
     """
-    value = NieMother.create(nie_case=NieCase.UPPERCASE)
+    value = NieMother.create(string_case=StringCase.UPPERCASE)
 
     assert value.isupper()
 
@@ -70,9 +69,9 @@ def test_nie_mother_mixed_case() -> None:
     """
     Test NieMother create method with mixed case.
     """
-    value = NieMother.create(nie_case=NieCase.MIXEDCASE)
+    value = NieMother.create(string_case=StringCase.MIXEDCASE)
 
-    assert any(char.islower() or char.isupper() for char in value)
+    assert all(char.islower() or char.isupper() or char.isdigit() for char in value)
 
 
 @mark.unit_testing
@@ -82,9 +81,9 @@ def test_nie_mother_invalid_case() -> None:
     """
     with assert_raises(
         expected_exception=TypeError,
-        match='NieMother nie_case must be a NieCase',
+        match='NieMother string_case must be a StringCase',
     ):
-        NieMother.create(nie_case=StringMother.invalid_type())
+        NieMother.create(string_case=StringMother.invalid_type())
 
 
 @mark.unit_testing

--- a/tests/mothers/internet/test_domain_mother.py
+++ b/tests/mothers/internet/test_domain_mother.py
@@ -4,9 +4,8 @@ Test module for the DomainMother class.
 
 from pytest import mark, raises as assert_raises
 
-from object_mother_pattern.mothers import BooleanMother, IntegerMother, StringMother
+from object_mother_pattern.mothers import BooleanMother, IntegerMother, StringCase, StringMother
 from object_mother_pattern.mothers.internet import DomainMother
-from object_mother_pattern.mothers.internet.domain_mother import DomainCase
 from object_mother_pattern.mothers.internet.utils import get_label_dict, get_tld_dict
 
 
@@ -404,7 +403,7 @@ def test_domain_mother_lowercase_case() -> None:
     """
     Test DomainMother create method with lowercase case.
     """
-    value = DomainMother.create(domain_case=DomainCase.LOWERCASE)
+    value = DomainMother.create(string_case=StringCase.LOWERCASE)
 
     assert value.islower()
 
@@ -414,7 +413,7 @@ def test_domain_mother_uppercase_case() -> None:
     """
     Test DomainMother create method with uppercase case.
     """
-    value = DomainMother.create(domain_case=DomainCase.UPPERCASE)
+    value = DomainMother.create(string_case=StringCase.UPPERCASE)
 
     assert value.isupper()
 
@@ -424,9 +423,9 @@ def test_domain_mother_mixed_case() -> None:
     """
     Test DomainMother create method with mixed case.
     """
-    value = DomainMother.create(domain_case=DomainCase.MIXEDCASE)
+    value = DomainMother.create(string_case=StringCase.MIXEDCASE)
 
-    assert any(char.islower() or char.isupper() for char in value)
+    assert all(char.islower() or char.isupper() or char.isdigit() or char == '-' or char == '.' for char in value)
 
 
 @mark.unit_testing
@@ -436,9 +435,9 @@ def test_domain_mother_invalid_case() -> None:
     """
     with assert_raises(
         expected_exception=TypeError,
-        match='DomainMother domain_case must be a DomainCase.',
+        match='DomainMother string_case must be a StringCase.',
     ):
-        DomainMother.create(domain_case=StringMother.invalid_type())
+        DomainMother.create(string_case=StringMother.invalid_type())
 
 
 @mark.unit_testing

--- a/tests/mothers/internet/test_mac_address_mother.py
+++ b/tests/mothers/internet/test_mac_address_mother.py
@@ -4,9 +4,9 @@ Test module for the MacAddressMother class.
 
 from pytest import mark, raises as assert_raises
 
-from object_mother_pattern.mothers import StringMother
+from object_mother_pattern.mothers import StringCase, StringMother
 from object_mother_pattern.mothers.internet import MacAddressMother
-from object_mother_pattern.mothers.internet.mac_address_mother import MacAddressCase, MacAddressFormat
+from object_mother_pattern.mothers.internet.mac_address_mother import MacAddressFormat
 
 
 @mark.unit_testing
@@ -47,9 +47,10 @@ def test_mac_address_mother_lowercase_case() -> None:
     """
     Test MacAddressMother create method with lowercase case.
     """
-    value = MacAddressMother.create(mac_case=MacAddressCase.LOWERCASE)
+    value = MacAddressMother.create(string_case=StringCase.LOWERCASE)
 
-    assert value.islower() or value == '00:00:00:00:00:00'
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert value.islower() or value.isdigit() or value == '000000000000'
 
 
 @mark.unit_testing
@@ -57,9 +58,10 @@ def test_mac_address_mother_uppercase_case() -> None:
     """
     Test MacAddressMother create method with uppercase case.
     """
-    value = MacAddressMother.create(mac_case=MacAddressCase.UPPERCASE)
+    value = MacAddressMother.create(string_case=StringCase.UPPERCASE)
 
-    assert value.isupper() or value == '00:00:00:00:00:00'
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert value.isupper() or value.isdigit() or value == '000000000000'
 
 
 @mark.unit_testing
@@ -67,9 +69,10 @@ def test_mac_address_mother_mixed_case() -> None:
     """
     Test MacAddressMother create method with mixed case.
     """
-    value = MacAddressMother.create(mac_case=MacAddressCase.MIXEDCASE)
+    value = MacAddressMother.create(string_case=StringCase.MIXEDCASE)
 
-    assert any(char.islower() or char.isupper() for char in value) or value == '00:00:00:00:00:00'
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert all(char.islower() or char.isupper() or char.isdigit() for char in value) or value == '000000000000'
 
 
 @mark.unit_testing
@@ -79,9 +82,9 @@ def test_mac_address_mother_invalid_case() -> None:
     """
     with assert_raises(
         expected_exception=ValueError,
-        match='MacAddressMother mac_case must be a MacAddressCase.',
+        match='MacAddressMother string_case must be a StringCase.',
     ):
-        MacAddressMother.create(mac_case=StringMother.invalid_type())
+        MacAddressMother.create(string_case=StringMother.invalid_type())
 
 
 @mark.unit_testing
@@ -105,7 +108,8 @@ def test_mac_address_mother_universal_format() -> None:
 
     assert len(value) == 17
     assert value.count(':') == 5
-    assert all(char.isalnum() or char == ':' for char in value)
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert all(char.isalnum() for char in value)
 
 
 @mark.unit_testing
@@ -117,7 +121,8 @@ def test_mac_address_mother_windows_format() -> None:
 
     assert len(value) == 17
     assert value.count('-') == 5
-    assert all(char.isalnum() or char == '-' for char in value)
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert all(char.isalnum() for char in value)
 
 
 @mark.unit_testing
@@ -128,7 +133,8 @@ def test_mac_address_mother_cisco_format() -> None:
     value = MacAddressMother.create(mac_format=MacAddressFormat.CISCO)
 
     assert value.count('.') == 2
-    assert all(char.isalnum() or char == '.' for char in value)
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert all(char.isalnum() for char in value)
 
 
 @mark.unit_testing
@@ -140,7 +146,8 @@ def test_mac_address_mother_space_format() -> None:
 
     assert len(value) == 17
     assert value.count(' ') == 5
-    assert all(char.isalnum() or char == ' ' for char in value)
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert all(char.isalnum() for char in value)
 
 
 @mark.unit_testing
@@ -183,7 +190,8 @@ def test_mac_address_mother_lowercase_method() -> None:
     value = MacAddressMother.lowercase()
 
     assert type(value) is str
-    assert value.islower() or value == '00:00:00:00:00:00'
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert value.islower() or value.isdigit() or value == '000000000000'
 
 
 @mark.unit_testing
@@ -194,7 +202,8 @@ def test_mac_address_mother_uppercase_method() -> None:
     value = MacAddressMother.uppercase()
 
     assert type(value) is str
-    assert value.isupper() or value == '00:00:00:00:00:00'
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert value.isupper() or value.isdigit() or value == '000000000000'
 
 
 @mark.unit_testing
@@ -205,7 +214,8 @@ def test_mac_address_mother_mixed_method() -> None:
     value = MacAddressMother.mixed()
 
     assert type(value) is str
-    assert any(char.islower() or char.isupper() for char in value) or value == '00:00:00:00:00:00'
+    value = ''.join(char for char in value if char not in (':', '-', ' ', '.', ' '))
+    assert all(char.islower() or char.isupper() or char.isdigit() for char in value) or value == '000000000000'
 
 
 @mark.unit_testing

--- a/tests/mothers/money/cryptocurrencies/test_btc_wallet_mother.py
+++ b/tests/mothers/money/cryptocurrencies/test_btc_wallet_mother.py
@@ -4,9 +4,8 @@ Test module for the BtcWalletMother class.
 
 from pytest import mark, raises as assert_raises
 
-from object_mother_pattern.mothers import IntegerMother, StringMother
+from object_mother_pattern.mothers import IntegerMother, StringCase, StringMother
 from object_mother_pattern.mothers.money.cryptocurrencies import BtcWalletMother
-from object_mother_pattern.mothers.money.cryptocurrencies.btc_wallet_mother import BtcWalletCase
 
 
 @mark.unit_testing
@@ -102,7 +101,7 @@ def test_btc_wallet_mother_lowercase_case() -> None:
     """
     Test BtcWalletMother create method with lowercase case.
     """
-    value = BtcWalletMother.create(wallet_case=BtcWalletCase.LOWERCASE)
+    value = BtcWalletMother.create(string_case=StringCase.LOWERCASE)
 
     assert value.islower()
 
@@ -112,7 +111,7 @@ def test_btc_wallet_mother_uppercase_case() -> None:
     """
     Test BtcWalletMother create method with uppercase case.
     """
-    value = BtcWalletMother.create(wallet_case=BtcWalletCase.UPPERCASE)
+    value = BtcWalletMother.create(string_case=StringCase.UPPERCASE)
 
     assert value.isupper()
 
@@ -122,9 +121,9 @@ def test_btc_wallet_mother_mixed_case() -> None:
     """
     Test BtcWalletMother create method with mixed case.
     """
-    value = BtcWalletMother.create(wallet_case=BtcWalletCase.MIXEDCASE)
+    value = BtcWalletMother.create(string_case=StringCase.MIXEDCASE)
 
-    assert any(char.islower() or char.isupper() for char in value)
+    assert all(char.islower() or char.isupper() or char.isspace() for char in value)
 
 
 @mark.unit_testing
@@ -134,6 +133,6 @@ def test_btc_wallet_mother_invalid_case() -> None:
     """
     with assert_raises(
         expected_exception=TypeError,
-        match='BtcWalletMother wallet_case must be a BtcWalletCase.',
+        match='BtcWalletMother string_case must be a StringCase.',
     ):
-        BtcWalletMother.create(wallet_case=StringMother.invalid_type())
+        BtcWalletMother.create(string_case=StringMother.invalid_type())

--- a/tests/mothers/people/test_full_name_mother.py
+++ b/tests/mothers/people/test_full_name_mother.py
@@ -4,9 +4,8 @@ Test module for the FullNameMother class.
 
 from pytest import mark, raises as assert_raises
 
-from object_mother_pattern.mothers import IntegerMother, StringMother
+from object_mother_pattern.mothers import IntegerMother, StringCase, StringMother
 from object_mother_pattern.mothers.people import FullNameMother
-from object_mother_pattern.mothers.people.full_name_mother import FullNameCase
 
 
 @mark.unit_testing
@@ -120,7 +119,7 @@ def test_full_name_mother_case_lowercase() -> None:
     """
     Test FullNameMother create method with lowercase case.
     """
-    value = FullNameMother.create(full_name_case=FullNameCase.LOWERCASE)
+    value = FullNameMother.create(string_case=StringCase.LOWERCASE)
 
     assert value.islower()
 
@@ -130,18 +129,9 @@ def test_full_name_mother_case_uppercase() -> None:
     """
     Test FullNameMother create method with uppercase case.
     """
-    value = FullNameMother.create(full_name_case=FullNameCase.UPPERCASE)
+    value = FullNameMother.create(string_case=StringCase.UPPERCASE)
 
     assert value.isupper()
-
-
-@mark.unit_testing
-def test_full_name_mother_case_titlecase() -> None:
-    """
-    Test FullNameMother create method with titlecase case.
-    """
-    value = FullNameMother.create(full_name_case=FullNameCase.TITLECASE)
-    assert value.istitle()
 
 
 @mark.unit_testing
@@ -149,9 +139,9 @@ def test_full_name_mother_case_mixed() -> None:
     """
     Test FullNameMother create method with mixed case.
     """
-    value = FullNameMother.create(full_name_case=FullNameCase.MIXEDCASE)
+    value = FullNameMother.create(string_case=StringCase.MIXEDCASE)
 
-    assert any(char.islower() or char.isupper() for char in value)
+    assert all(char.islower() or char.isupper() or char.isspace() or char == '.' for char in value)
 
 
 @mark.unit_testing
@@ -159,8 +149,8 @@ def test_full_name_mother_invalid_full_name_case_type() -> None:
     """
     Test FullNameMother create method with invalid full name case type.
     """
-    with assert_raises(TypeError, match='FullNameMother full_name_case must be a FullNameCase.'):
-        FullNameMother.create(full_name_case=StringMother.invalid_type())
+    with assert_raises(TypeError, match='FullNameMother string_case must be a StringCase.'):
+        FullNameMother.create(string_case=StringMother.invalid_type())
 
 
 @mark.unit_testing

--- a/tests/mothers/primitives/test_string_mother.py
+++ b/tests/mothers/primitives/test_string_mother.py
@@ -709,7 +709,7 @@ def test_string_mother_mixedcase_method_happy_path() -> None:
 
     assert type(value) is str
     assert 1 <= len(value) <= 128
-    assert any(char.islower() or char.isupper() for char in value)
+    assert all(char.islower() or char.isupper() or char.isdigit() for char in value)
 
 
 @mark.unit_testing


### PR DESCRIPTION
# 📑 Description
This pull request introduces a refactor to consolidate multiple string case enums (`TextCase`, `DniCase`, `NieCase`, `DomainCase`, `MacAddressCase`) into a single reusable `StringCase` enum. This change simplifies the codebase by eliminating duplicate logic and improving maintainability.

## 🔖 Type of change

- [x] **✨ feat**: New feature (non-breaking change).
- [ ] **🐛 fix**: Bug fix (non-breaking change).
- [ ] **📚 docs**: Documentation update.
- [ ] **🔨 refactor**: Code change that neither fixes a bug nor adds a new feature.
- [ ] **🚀 perf**: Performance improvement.
- [ ] **🧪 test**: Update suite of tests.
- [ ] **📦 build**: Changes that affect the build system (new dependencies, tools, ...).
- [ ] **🤖 ci**: Pipeline changes (GitHub Actions, make commands, ...).
- [x] **💥BREAKING CHANGE**: Feature, fix, ... that breaks backward compatibility.
- [ ] **🛠️ others**: Other type of change.

## 🔗 Related Issues / Discussions / Resources

<!--
> 📝 Please include a list of related issues, discussions, or resources.
> - Closes: [#\<issue-number>](https://github.com/adriamontoto/object-mother-pattern/issues/<issue-number>), ...
> - Related to: [#\<issue-number>](https://github.com/adriamontoto/object-mother-pattern/issues/<issue-number>), ...
-->

## ✅ Pre-merge Checklist

- [x] I have read and followed the [`🤝 Contributor Guidelines`](https://github.com/adriamontoto/object-mother-pattern/blob/master/.github/CONTRIBUTING.md).
- [x] I have read and followed the [`🧭 Code of Conduct`](https://github.com/adriamontoto/object-mother-pattern/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] My pull requests and commits follow the [Conventional Commits](https://www.conventionalcommits.org) and [Conventional Comments](https://conventionalcomments.org) guidelines.
- [x] My code follows the coding guidelines of the project ([PEP 8](https://peps.python.org/pep-0008), [PEP 257](https://peps.python.org/pep-0257), ...).
- [x] My changes generate no new warnings (execution, linter, formatter, ...).
- [x] I have updated the suite of tests required for this change.
- [x] I have made corresponding changes to the documentation.
- [x] I considered security & backwards-compatibility; if **breaking**, explain in the "Description" section above.

## 📃 Additional Resources

- [The Anatomy of a Perfect Pull Request](https://hugooodias.medium.com/the-anatomy-of-a-perfect-pull-request-567382bb6067)
